### PR TITLE
chore: implement experiment output best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ from src import ecosim_v1_5 as ecosim
 python demos/demo_plot.py
 ```
 
+## How to Run Experiments
+
+Run any experiment from the repository root. Example:
+
+```bash
+cd edl-simulation
+python experiments/extended/edl_experiment_extended_v1.5.py
+```
+
+Each execution creates a time-stamped folder under `outputs/` named after the
+script, e.g. `outputs/edl_experiment_extended_v1.5_20240101_120000/`. All CSV
+tables and figures are saved there.
+
 ## Running Experiments
 
 Execute any experiment from the repository root. Examples:

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -1,0 +1,11 @@
+defaults = {
+    "n_actors": 100,
+    "n_steps": 120,
+    "density": 0.08,
+    "gamma": 0.08,
+    "lam": 0.05,
+    "R_cap": 10.0,
+    "alpha": 0.05,
+    "beta": 0.025,
+    "seed": 123,
+}

--- a/experiments/boosted/edl_boosted_experiment_v1.3.py
+++ b/experiments/boosted/edl_boosted_experiment_v1.3.py
@@ -27,6 +27,7 @@ effect_sizes.csv, group_summary.csv, final_snapshot.csv, param_log.json
 # ---------------------------------------------------------------------
 import json
 from pathlib import Path
+import datetime
 
 import matplotlib.pyplot as plt
 plt.style.use("seaborn-v0_8-muted")
@@ -36,22 +37,19 @@ import seaborn as sns
 from scipy import stats
 
 from src import ecosim_v1_5 as ecosim
+from config.defaults import defaults
 # ---------------------------------------------------------------------
-OUT = Path("outputs")
-OUT.mkdir(exist_ok=True)
+timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+OUT = Path(f"outputs/{Path(__file__).stem}_{timestamp}")
+OUT.mkdir(parents=True, exist_ok=True)
 
 # Common parameters for *all* conditions (incl. new v1.3 controls)
-COMMON = dict(
+COMMON = defaults.copy()
+COMMON.update(dict(
     n_actors=50,
     n_steps=100,
     density=0.05,
-    seed=123,
-    gamma=0.08,
-    lam=0.05,
-    alpha=0.05,   # milder operant boost strength
-    beta=0.025,   # milder operand boost strength
-    R_cap=10.0    # bound the orchestrant stock
-)
+))
 
 # Condition-specific boost flags
 CONDITIONS = {

--- a/experiments/extended/edl_experiment_extended_v1.5.py
+++ b/experiments/extended/edl_experiment_extended_v1.5.py
@@ -25,6 +25,7 @@ Figures: value_trajectories.png, component_decomposition.png, delta_plot.png,
 # -------------------------------------------------------------------
 import json
 from pathlib import Path
+import datetime
 
 import matplotlib.pyplot as plt
 plt.style.use("seaborn-v0_8-muted")
@@ -34,12 +35,13 @@ import seaborn as sns
 from scipy import stats
 
 from src import ecosim_v1_5 as ecosim
+from config.defaults import defaults
 # -------------------------------------------------------------------
-OUT = Path("outputs")
-OUT.mkdir(exist_ok=True)
+timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+OUT = Path(f"outputs/{Path(__file__).stem}_{timestamp}")
+OUT.mkdir(parents=True, exist_ok=True)
 
-COMMON = dict(n_actors=100, n_steps=120, density=0.08, seed=123,
-              gamma=0.08, lam=0.05, alpha=0.05, beta=0.025, R_cap=10.0)
+COMMON = defaults.copy()
 
 CONDITIONS = {
     "Baseline-Control": {},

--- a/experiments/field/edl_field_experiment_v1.0.py
+++ b/experiments/field/edl_field_experiment_v1.0.py
@@ -33,6 +33,7 @@ numpy, pandas, matplotlib, seaborn, scipy     (statsmodels optional)
 import argparse
 import json
 from pathlib import Path
+import datetime
 
 import matplotlib.pyplot as plt
 plt.style.use("seaborn-v0_8-muted")
@@ -42,10 +43,13 @@ import seaborn as sns
 from scipy import stats
 
 from src import ecosim_v1_5 as ecosim
+from config.defaults import defaults
 # --------------------------------------------------------------------------
-OUT = Path("outputs")
-OUT.mkdir(exist_ok=True)
-COMMON = dict(n_actors=50, n_steps=100, density=0.05, seed=123)
+timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+OUT = Path(f"outputs/{Path(__file__).stem}_{timestamp}")
+OUT.mkdir(parents=True, exist_ok=True)
+COMMON = defaults.copy()
+COMMON.update(dict(n_actors=50, n_steps=100, density=0.05))
 
 # Orchestrant parameter schedule per condition ------------------------------
 LOW   = dict(gamma=0.02, lam=0.01)

--- a/experiments/field/edl_simulated_experiment_v1.1.py
+++ b/experiments/field/edl_simulated_experiment_v1.1.py
@@ -17,6 +17,7 @@ uses `stats.f_oneway` for ANOVA.
 import argparse
 import json
 from pathlib import Path
+import datetime
 
 import matplotlib.pyplot as plt
 plt.style.use("seaborn-v0_8-muted")
@@ -26,10 +27,13 @@ import seaborn as sns
 from scipy import stats             # <-- keep module reference intact
 
 from src import ecosim_v1_5 as ecosim
+from config.defaults import defaults
 # --------------------------------------------------------------------------
-OUT = Path("outputs")
-OUT.mkdir(exist_ok=True)
-COMMON = dict(n_actors=50, n_steps=100, density=0.05, seed=123)
+timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+OUT = Path(f"outputs/{Path(__file__).stem}_{timestamp}")
+OUT.mkdir(parents=True, exist_ok=True)
+COMMON = defaults.copy()
+COMMON.update(dict(n_actors=50, n_steps=100, density=0.05))
 
 # Condition specifications ---------------------------------------------------
 LOW   = dict(gamma=0.02, lam=0.01)

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,40 @@
+import argparse
+import runpy
+from pathlib import Path
+
+SCRIPTS = {
+    "extended": "experiments/extended/edl_experiment_extended_v1.5.py",
+    "boosted": "experiments/boosted/edl_boosted_experiment_v1.3.py",
+    "field": "experiments/field/edl_field_experiment_v1.0.py",
+    "simulated": "experiments/field/edl_simulated_experiment_v1.1.py",
+}
+
+
+def run_script(name: str) -> Path:
+    path = SCRIPTS.get(name)
+    if not path:
+        raise ValueError(f"Unknown script '{name}'. Available: {list(SCRIPTS)}")
+    out_dir_before = set(Path('outputs').glob('*'))
+    runpy.run_path(path)
+    out_dir_after = set(Path('outputs').glob('*'))
+    new_dirs = [d for d in out_dir_after - out_dir_before if d.is_dir()]
+    for d in new_dirs:
+        print(f"Created output folder: {d}")
+    return new_dirs[0] if new_dirs else None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run EDL experiment scripts")
+    parser.add_argument("--script", required=True, choices=SCRIPTS.keys(),
+                        help="Which experiment to run")
+    parser.add_argument("--repeat", type=int, default=1,
+                        help="Number of times to run the script")
+    args = parser.parse_args()
+    for i in range(args.repeat):
+        print(f"\nRun {i+1}/{args.repeat} of {args.script}")
+        run_script(args.script)
+    print("Done. Check the outputs/ directory for results.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- configure timestamped output directories per experiment
- centralize default parameters in `config/defaults.py`
- add optional `runner.py` for CLI-driven experiments
- document running experiments in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bb777f8e483219050ed07978f4ade