### PR TITLE
fix: add sys.path hook for extended experiment

### DIFF
--- a/experiments/extended/edl_experiment_extended_v1.5.py
+++ b/experiments/extended/edl_experiment_extended_v1.5.py
@@ -23,6 +23,10 @@ Figures: value_trajectories.png, component_decomposition.png, delta_plot.png,
          rho_volatility.png
 """
 # -------------------------------------------------------------------
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
 import json
 from pathlib import Path
 import datetime


### PR DESCRIPTION
## Summary
- extend PYTHONPATH in `edl_experiment_extended_v1.5.py`

## Testing
- `python -m py_compile experiments/extended/edl_experiment_extended_v1.5.py`

------
https://chatgpt.com/codex/tasks/task_e_684bbe1ac9488321969649488eb90fa2